### PR TITLE
Fix z-index in landingPage header

### DIFF
--- a/app/static/sass/components/header.scss
+++ b/app/static/sass/components/header.scss
@@ -79,6 +79,7 @@ $lph-font-color: #000; //primary font color
   border-radius: 0;
   padding-top: 5px;
   background-color: rgba(255, 255, 255, 0.7);
+  z-index: 100;
   &__item {
     text-align: right;
     &:last-child {
@@ -140,7 +141,6 @@ $lph-font-color: #000; //primary font color
       height: 66px;
       top: 23px;
       background-color: rgba(255, 255, 255, 0.5);
-      z-index: -1;
     }
   }
 }


### PR DESCRIPTION
Add z-index in landingPage - headerNavigation. Now navigation alvays in front. This commit fix bug, when some element overlapp fixed and mobile navigation.